### PR TITLE
Add PaymentResponse wrapper

### DIFF
--- a/lib/lnrpc.rb
+++ b/lib/lnrpc.rb
@@ -11,6 +11,7 @@ module Lnrpc
   class Error < StandardError; end
   autoload :Client, 'lnrpc/client'
   autoload :GrpcWrapper, 'lnrpc/grpc_wrapper'
+  autoload :PaymentResponse, 'lnrpc/payment_response'
   autoload :MacaroonInterceptor, 'lnrpc/macaroon_interceptor'
 
   PREIMAGE_BYTE_LENGTH = 32

--- a/lib/lnrpc/client.rb
+++ b/lib/lnrpc/client.rb
@@ -75,12 +75,12 @@ module Lnrpc
       args[:dest_custom_records][Lnrpc::KEY_SEND_PREIMAGE_TYPE] ||= Lnrpc.create_preimage
       args[:payment_hash] ||= Digest::SHA256.digest(args[:dest_custom_records][Lnrpc::KEY_SEND_PREIMAGE_TYPE])
       args[:timeout_seconds] ||= 60
-      router.send_payment_v2(args)
+      PaymentResponse.new(router.send_payment_v2(args))
     end
 
     def pay(args)
       args[:timeout_seconds] ||= 60
-      router.send_payment_v2(args)
+      PaymentResponse.new(router.send_payment_v2(args))
     end
 
     def inspect

--- a/lib/lnrpc/payment_response.rb
+++ b/lib/lnrpc/payment_response.rb
@@ -1,0 +1,30 @@
+module Lnrpc
+  class PaymentResponse
+    attr_reader :grpc_response, :exception
+
+    def initialize(send_payment_response)
+      @grpc_response = send_payment_response
+    end
+
+    def states
+      @states ||= response_array.map(&:status)
+    end
+
+    def success?
+      return false if exception
+
+      @success ||= states.include?(:SUCCEEDED)
+    end
+
+    def fee
+      @fee ||= response_array.sum(&:fee)
+    end
+
+    def response_array
+      @response_array ||= @grpc_response.to_a
+    rescue GRPC::BadStatus => e
+      @exception = e
+      []
+    end
+  end
+end


### PR DESCRIPTION
This is an experimental wrapper around the send_payment shortcut calls.
The goal is to provide a simple interface to check if the payment was successful.